### PR TITLE
Feat: ai 여행 플래너 테마 선택 페이지 구현

### DIFF
--- a/howaboutthere-fe/src/components/Card/AIScheduleFormCard.tsx
+++ b/howaboutthere-fe/src/components/Card/AIScheduleFormCard.tsx
@@ -76,7 +76,7 @@ export default function AIScheduleFormCard() {
                 <FormControl>
                   <RadioGroup onValueChange={field.onChange} defaultValue={field.value} className="flex gap-3">
                     {REGIONS.map((region) => (
-                      <FormItem className="flex items-center space-x-2 space-y-0">
+                      <FormItem key={region.value} className="flex items-center space-x-2 space-y-0">
                         <FormControl>
                           <RadioGroupItem value={region.value} />
                         </FormControl>

--- a/howaboutthere-fe/src/components/Domain/AIScheduleTheme/AIScheduleThemeCard.tsx
+++ b/howaboutthere-fe/src/components/Domain/AIScheduleTheme/AIScheduleThemeCard.tsx
@@ -1,0 +1,44 @@
+import mocks from "@/mocks/ai-schedule-theme-mock.json";
+
+import { useForm } from "react-hook-form";
+import { Button } from "../../ui/button";
+import { Form, FormField } from "../../ui/form";
+import Card from "../../Card/Card";
+import { ThemeType } from "@/types/theme-type";
+import ScheduleThemeItem from "./ScheduleThemeList/ScheduleThemeItem";
+
+type AIScheduleThemeType = {
+  theme: ThemeType;
+};
+
+export default function AIScheduleThemeCard() {
+  const form = useForm<AIScheduleThemeType>();
+  const themes = mocks;
+
+  return (
+    <Card title={"테마 선택"} description={"어떤 테마로 여행을 떠나볼까요?"}>
+      <Form {...form}>
+        <form className="flex flex-col gap-4">
+          <FormField
+            control={form.control}
+            name={"theme"}
+            render={({ field }) => (
+              <ol className="flex flex-col w-full p-0 gap-1">
+                {themes.result.map((theme) => (
+                  <ScheduleThemeItem
+                    key={theme.country}
+                    imgSrc="https://images.unsplash.com/photo-1597246217838-bfc44d6ac746?q=80&w=1170&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"
+                    isSelected={field.value && field.value.country === theme.country}
+                    onSelect={() => field.onChange(theme)}
+                    {...theme}
+                  />
+                ))}
+              </ol>
+            )}
+          ></FormField>
+          <Button type="submit">다음</Button>
+        </form>
+      </Form>
+    </Card>
+  );
+}

--- a/howaboutthere-fe/src/components/Domain/AIScheduleTheme/ScheduleThemeList/ScheduleThemeItem.tsx
+++ b/howaboutthere-fe/src/components/Domain/AIScheduleTheme/ScheduleThemeList/ScheduleThemeItem.tsx
@@ -1,15 +1,32 @@
 import { Badge } from "@/components/ui/badge";
+import { Selectable } from "@/types/form";
 import { ThemeType } from "@/types/theme-type";
+import { cn } from "@/lib/utils";
 
-type ScheduleThemeItemType = ThemeType & {
-  imgSrc?: string;
-};
+type ScheduleThemeItemType = Selectable &
+  ThemeType & {
+    imgSrc?: string;
+  };
 
-export default function ScheduleThemeItem({ country, city, travelType, imgSrc }: ScheduleThemeItemType) {
+export default function ScheduleThemeItem({
+  country,
+  city,
+  travelType,
+  imgSrc,
+  isSelected,
+  onSelect,
+}: ScheduleThemeItemType) {
   return (
-    <li className="p-2 border border-r-8 rounded-lg list-none">
+    <li
+      className={cn(
+        "p-2 border border-r-8 rounded-lg list-none bg-white m-0",
+        isSelected && "bg-sky-100",
+        !isSelected && "hover:bg-sky-50"
+      )}
+      onClick={onSelect}
+    >
       <div className="flex justify-between items-center">
-        <div className="overflow-hidden w-24">
+        <div className="shrink-0 overflow-hidden w-24">
           {imgSrc && (
             <img
               className="aspect-video object-cover object-center m-0"

--- a/howaboutthere-fe/src/components/Domain/AIScheduleTheme/ScheduleThemeList/ScheduleThemeItem.tsx
+++ b/howaboutthere-fe/src/components/Domain/AIScheduleTheme/ScheduleThemeList/ScheduleThemeItem.tsx
@@ -1,0 +1,33 @@
+import { Badge } from "@/components/ui/badge";
+import { ThemeType } from "@/types/theme-type";
+
+type ScheduleThemeItemType = ThemeType & {
+  imgSrc?: string;
+};
+
+export default function ScheduleThemeItem({ country, city, travelType, imgSrc }: ScheduleThemeItemType) {
+  return (
+    <li className="p-2 border border-r-8 rounded-lg list-none">
+      <div className="flex justify-between items-center">
+        <div className="overflow-hidden w-24">
+          {imgSrc && (
+            <img
+              className="aspect-video object-cover object-center m-0"
+              src={imgSrc}
+              alt={`${country}-${city}-${travelType} Image`}
+            />
+          )}
+        </div>
+        <div className="flex flex-col items-end sm:flex-row sm:gap-3 sm:items-center">
+          <div className="flex flex-row gap-2 items-center">
+            <Badge className="rounded-full h-fit" variant="outline">
+              <span>{country}</span>
+            </Badge>
+            <h3 className="text-sky-700">{city}</h3>
+          </div>
+          <h4 className="text-stone-700">{travelType}</h4>
+        </div>
+      </div>
+    </li>
+  );
+}

--- a/howaboutthere-fe/src/components/ui/badge.tsx
+++ b/howaboutthere-fe/src/components/ui/badge.tsx
@@ -1,0 +1,36 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const badgeVariants = cva(
+  "inline-flex items-center rounded-md border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  {
+    variants: {
+      variant: {
+        default:
+          "border-transparent bg-primary text-primary-foreground shadow hover:bg-primary/80",
+        secondary:
+          "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        destructive:
+          "border-transparent bg-destructive text-destructive-foreground shadow hover:bg-destructive/80",
+        outline: "text-foreground",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {}
+
+function Badge({ className, variant, ...props }: BadgeProps) {
+  return (
+    <div className={cn(badgeVariants({ variant }), className)} {...props} />
+  )
+}
+
+export { Badge, badgeVariants }

--- a/howaboutthere-fe/src/components/ui/badge.tsx
+++ b/howaboutthere-fe/src/components/ui/badge.tsx
@@ -14,7 +14,7 @@ const badgeVariants = cva(
           "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80",
         destructive:
           "border-transparent bg-destructive text-destructive-foreground shadow hover:bg-destructive/80",
-        outline: "text-foreground",
+        outline: "text-foreground bg-white",
       },
     },
     defaultVariants: {

--- a/howaboutthere-fe/src/index.css
+++ b/howaboutthere-fe/src/index.css
@@ -62,7 +62,7 @@
   }
   body {
     @apply bg-background text-foreground;
-    @apply prose prose-base;
+    @apply prose prose-base sm:prose-lg md:prose-xl lg:prose-2xl;
 
     min-width: 100dvw;
     min-height: 100dvh;

--- a/howaboutthere-fe/src/index.css
+++ b/howaboutthere-fe/src/index.css
@@ -62,7 +62,7 @@
   }
   body {
     @apply bg-background text-foreground;
-    @apply prose prose-base sm:prose-lg md:prose-xl lg:prose-2xl;
+    @apply prose prose-sm sm:prose-base md:prose-lg lg:prose-xl;
 
     min-width: 100dvw;
     min-height: 100dvh;

--- a/howaboutthere-fe/src/mocks/ai-schedule-theme-mock.json
+++ b/howaboutthere-fe/src/mocks/ai-schedule-theme-mock.json
@@ -1,0 +1,54 @@
+{
+  "result": [
+    {
+      "country": "일본",
+      "city": "교토",
+      "travelType": "문화 체험"
+    },
+    {
+      "country": "이탈리아",
+      "city": "로마",
+      "travelType": "역사 탐방"
+    },
+    {
+      "country": "태국",
+      "city": "푸켓",
+      "travelType": "해변 휴양"
+    },
+    {
+      "country": "프랑스",
+      "city": "파리",
+      "travelType": "로맨틱 여행"
+    },
+    {
+      "country": "스페인",
+      "city": "바르셀로나",
+      "travelType": "미식 여행"
+    },
+    {
+      "country": "스위스",
+      "city": "인터라켄",
+      "travelType": "자연 체험"
+    },
+    {
+      "country": "체코",
+      "city": "프라하",
+      "travelType": "중세 도시 탐방"
+    },
+    {
+      "country": "베트남",
+      "city": "호이안",
+      "travelType": "전통 문화 체험"
+    },
+    {
+      "country": "호주",
+      "city": "시드니",
+      "travelType": "도시 관광"
+    },
+    {
+      "country": "터키",
+      "city": "카파도키아",
+      "travelType": "이색 체험"
+    }
+  ]
+}

--- a/howaboutthere-fe/src/pages/ui-components/UIComponents.tsx
+++ b/howaboutthere-fe/src/pages/ui-components/UIComponents.tsx
@@ -1,4 +1,6 @@
 import AIScheduleFormCard from "@/components/Card/AIScheduleFormCard";
+import AIScheduleThemeCard from "@/components/Domain/AIScheduleTheme/AIScheduleThemeCard";
+import ScheduleThemeItem from "@/components/Domain/AIScheduleTheme/ScheduleThemeList/ScheduleThemeItem";
 
 export default function UIComponents() {
   return (
@@ -7,6 +9,22 @@ export default function UIComponents() {
       <div className="p-6">
         <h2 className="mb-4 text-rose-500">AIScheduleFormCard</h2>
         <AIScheduleFormCard />
+      </div>
+      <div className="p-6">
+        <h2 className="mb-4 text-rose-500">AIScheduleThemeCard</h2>
+        <AIScheduleThemeCard />
+      </div>
+      <div className="p-6">
+        <h2 className="mb-4 text-rose-500">ScheduleThemeItem</h2>
+        <ScheduleThemeItem
+          country={"태국"}
+          city={"푸켓"}
+          travelType={"해변 휴양"}
+          imgSrc="https://images.unsplash.com/photo-1597246217838-bfc44d6ac746?q=80&w=1170&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"
+          onSelect={function (): void {
+            throw new Error("Function not implemented.");
+          }}
+        />
       </div>
     </div>
   );

--- a/howaboutthere-fe/src/types/form.ts
+++ b/howaboutthere-fe/src/types/form.ts
@@ -1,0 +1,4 @@
+export type Selectable = {
+  isSelected?: boolean;
+  onSelect: () => void;
+};

--- a/howaboutthere-fe/src/types/theme-type.ts
+++ b/howaboutthere-fe/src/types/theme-type.ts
@@ -1,0 +1,5 @@
+export type ThemeType = {
+  country: string;
+  city: string;
+  travelType: string;
+};


### PR DESCRIPTION
# 작업 내용
- [x] AIScheduleThemeCard 구현
- [x] Selectable 타입 정의
- [x] 반응형 폰트 사이즈 지정

## AIScheduleThemeCard 구현
![AIScheduleThemeCard](https://github.com/user-attachments/assets/742513f0-f682-4a66-b650-6a1312109e74)

### 선택 가능한 요소 구현
- Selectable 타입 정의
```ts
export type Selectable = {
  isSelected?: boolean;
  onSelect: () => void;
};

type ScheduleThemeItemType = Selectable &
  ThemeType

export default function ScheduleThemeItem({
//...
  isSelected,
  onSelect,
}: ScheduleThemeItemType) {
  return (
    <li
      className={cn(
        isSelected && "bg-sky-100",
        !isSelected && "hover:bg-sky-50"
      )}
      onClick={onSelect}
    >
    //...
    </li>
```

## 반응형 폰트 사이즈 지정
![반응형 폰트 사이즈 지정](https://github.com/user-attachments/assets/b66c723d-13ef-42eb-9cc1-e74f6617417d)

### 브라우즈 너비에 따른 폰트 사이즈 변경
- @tailwindcss/typography util 사용
- 반응형에 따른 사이즈 지정

```CSS
@apply prose prose-base sm:prose-lg md:prose-xl lg:prose-2xl;
```