### PR TITLE
Feat ai 여행 플래너 ai 여행 계획 페이지 구현

### DIFF
--- a/howaboutthere-fe/src/assets/icon/arrow-left.svg
+++ b/howaboutthere-fe/src/assets/icon/arrow-left.svg
@@ -1,0 +1,6 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="arrow-left">
+<path id="Vector" d="M12.6666 8H3.33325" stroke="#020617" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path id="Vector_2" d="M7.99992 12.6666L3.33325 7.99998L7.99992 3.33331" stroke="#020617" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+</svg>

--- a/howaboutthere-fe/src/assets/icon/arrow-right.svg
+++ b/howaboutthere-fe/src/assets/icon/arrow-right.svg
@@ -1,0 +1,6 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="arrow-right">
+<path id="Vector" d="M3.33325 8H12.6666" stroke="#020617" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path id="Vector_2" d="M8 3.33331L12.6667 7.99998L8 12.6666" stroke="#020617" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+</svg>

--- a/howaboutthere-fe/src/components/Domain/AISchedule/AISchedulePlan/AISchedulePlanCard.tsx
+++ b/howaboutthere-fe/src/components/Domain/AISchedule/AISchedulePlan/AISchedulePlanCard.tsx
@@ -27,7 +27,7 @@ export default function AIScheduleLocationCard() {
   const [currentDay, setCurrentDay] = useState(0);
   const [_, setCurrentPolyline] = useState<google.maps.Polyline | null>(null);
 
-  const map = useMap("ai-schedule-location-map");
+  const map = useMap("ai-schedule-plan-map");
 
   useLayoutEffect(() => {
     if (map && plans?.result[currentDay]?.schedule) {
@@ -56,7 +56,7 @@ export default function AIScheduleLocationCard() {
     <Card title={"AI 여행 계획"} description={"선택한 여행지를 기반으로 완성한 일정입니다"}>
       <div className="flex flex-col gap-8">
         <div className=" border rounded-xl overflow-hidden">
-          <Map id="ai-schedule-location-map">
+          <Map id="ai-schedule-plan-map">
             {plans?.result[currentDay]?.schedule?.map((plan) => {
               return "latlng" in plan ? (
                 <MapPin key={`${plan.latlng.lat}-${plan.latlng.lng}`} position={plan.latlng} />

--- a/howaboutthere-fe/src/components/Domain/AISchedule/AISchedulePlan/AISchedulePlanCard.tsx
+++ b/howaboutthere-fe/src/components/Domain/AISchedule/AISchedulePlan/AISchedulePlanCard.tsx
@@ -22,7 +22,7 @@ type PlanAPIResponse = {
   }>;
 };
 
-export default function AIScheduleLocationCard() {
+export default function AISchedulePlanCard() {
   const plans: PlanAPIResponse = mocks as PlanAPIResponse;
   const [currentDay, setCurrentDay] = useState(0);
   const [_, setCurrentPolyline] = useState<google.maps.Polyline | null>(null);

--- a/howaboutthere-fe/src/components/Domain/AISchedule/AISchedulePlan/AISchedulePlanCard.tsx
+++ b/howaboutthere-fe/src/components/Domain/AISchedule/AISchedulePlan/AISchedulePlanCard.tsx
@@ -1,0 +1,90 @@
+import arrowLeft from "@/assets/icon/arrow-left.svg";
+import arrowRight from "@/assets/icon/arrow-right.svg";
+
+import mocks from "@/mocks/ai-schedule-plan-mock.json";
+
+import Card from "@/components/Card/Card";
+import Map from "@/components/Map/Map";
+import { useMap } from "@vis.gl/react-google-maps";
+import { useLayoutEffect, useState } from "react";
+import { getBoundFromPoints } from "@/utils/mapUtil";
+import MapPin from "@/components/Map/MapPin";
+import SchedulePlanSummary from "./SchedulePlanSummary";
+import SchedulePlanListItem from "./SchedulePlanList/SchedulePlanListItem";
+import { ActivityPlan, TransportPlan } from "@/types/plan-type";
+import { Button } from "@/components/ui/button";
+
+type PlanAPIResponse = {
+  result: Array<{
+    date: string;
+    description: string;
+    schedule: Array<ActivityPlan | TransportPlan>;
+  }>;
+};
+
+export default function AIScheduleLocationCard() {
+  const plans: PlanAPIResponse = mocks as PlanAPIResponse;
+  const [currentDay, setCurrentDay] = useState(0);
+
+  const map = useMap("ai-schedule-location-map");
+
+  useLayoutEffect(() => {
+    if (map && plans?.result[currentDay]?.schedule) {
+      const points = plans.result[currentDay].schedule.filter((plan) => "latlng" in plan).map((plan) => plan.latlng);
+      console.log(points);
+      const bounds = getBoundFromPoints(points);
+      map.fitBounds(bounds);
+    }
+  }, [currentDay, map, plans.result]);
+
+  return (
+    <Card title={"AI 여행 계획"} description={"선택한 여행지를 기반으로 완성한 일정입니다"}>
+      <div className="flex flex-col gap-8">
+        <div className=" border rounded-xl overflow-hidden">
+          <Map id="ai-schedule-location-map">
+            {plans?.result[currentDay]?.schedule?.map((plan) => {
+              return "latlng" in plan ? (
+                <MapPin key={`${plan.latlng.lat}-${plan.latlng.lng}`} position={plan.latlng} />
+              ) : null;
+            })}
+          </Map>
+        </div>
+        <SchedulePlanSummary
+          summary={
+            "오늘은 베트남의 역사와 문화에 깊이 빠져드는 날입니다. 참 박물관에서 베트남 전쟁의 역사를 배우고, 마블마운틴의 영적인 분위기를 느낀 후, 전통 요리 클래스로 베트남 음식 문화를 직접 체험합니다. 과거와 현재가 공존하는 베트남의 다채로운 모습을 경험하는 의미 있는 하루가 될 것입니다."
+          }
+        />
+        <article className="relative p-2 flex flex-col gap-4 items-center rounded-lg bg-sky-50 overflow-hidden">
+          <div className="flex flex-row items-center justify-between">
+            <div className="flex flex-row items-center gap-4">
+              <Button
+                onClick={() => setCurrentDay((prev) => Math.max(0, prev - 1))}
+                className="w-8 h-8 rounded-full p-0"
+                variant="outline"
+              >
+                <img className="w-4 h-4 object-contain" src={arrowLeft} alt="이전" />
+              </Button>
+              <h2 className="text-sky-900">{currentDay + 1} 일차</h2>
+
+              <Button
+                onClick={() => setCurrentDay((prev) => Math.min(plans.result.length - 1, prev + 1))}
+                className="w-8 h-8  rounded-full p-0"
+                variant="outline"
+              >
+                <img className="w-4 h-4 object-contain" src={arrowRight} alt="다음" />
+              </Button>
+            </div>
+          </div>
+          <div className="relative w-full ">
+            <div className="absolute z-0 top-0 left-1/2 -translate-x-0.5 w-px h-full border border-dotted border-sky-500" />
+            <div className="relative  flex flex-col items-center gap-2">
+              {plans?.result[currentDay]?.schedule?.map((plan) => (
+                <SchedulePlanListItem key={plan.id} {...plan} />
+              ))}
+            </div>
+          </div>
+        </article>
+      </div>
+    </Card>
+  );
+}

--- a/howaboutthere-fe/src/components/Domain/AISchedule/AISchedulePlan/AISchedulePlanCard.tsx
+++ b/howaboutthere-fe/src/components/Domain/AISchedule/AISchedulePlan/AISchedulePlanCard.tsx
@@ -25,7 +25,7 @@ type PlanAPIResponse = {
 export default function AIScheduleLocationCard() {
   const plans: PlanAPIResponse = mocks as PlanAPIResponse;
   const [currentDay, setCurrentDay] = useState(0);
-  const [currentPolyline, setCurrentPolyline] = useState<google.maps.Polyline | null>(null);
+  const [_, setCurrentPolyline] = useState<google.maps.Polyline | null>(null);
 
   const map = useMap("ai-schedule-location-map");
 
@@ -64,11 +64,7 @@ export default function AIScheduleLocationCard() {
             })}
           </Map>
         </div>
-        <SchedulePlanSummary
-          summary={
-            "오늘은 베트남의 역사와 문화에 깊이 빠져드는 날입니다. 참 박물관에서 베트남 전쟁의 역사를 배우고, 마블마운틴의 영적인 분위기를 느낀 후, 전통 요리 클래스로 베트남 음식 문화를 직접 체험합니다. 과거와 현재가 공존하는 베트남의 다채로운 모습을 경험하는 의미 있는 하루가 될 것입니다."
-          }
-        />
+        <SchedulePlanSummary summary={plans?.result[currentDay]?.description} />
         <article className="relative p-2 flex flex-col gap-4 items-center rounded-lg bg-sky-50 overflow-hidden">
           <div className="flex flex-row items-center justify-between">
             <div className="flex flex-row items-center gap-4">

--- a/howaboutthere-fe/src/components/Domain/AISchedule/AISchedulePlan/AISchedulePlanCard.tsx
+++ b/howaboutthere-fe/src/components/Domain/AISchedule/AISchedulePlan/AISchedulePlanCard.tsx
@@ -25,6 +25,7 @@ type PlanAPIResponse = {
 export default function AIScheduleLocationCard() {
   const plans: PlanAPIResponse = mocks as PlanAPIResponse;
   const [currentDay, setCurrentDay] = useState(0);
+  const [currentPolyline, setCurrentPolyline] = useState<google.maps.Polyline | null>(null);
 
   const map = useMap("ai-schedule-location-map");
 
@@ -34,6 +35,20 @@ export default function AIScheduleLocationCard() {
       console.log(points);
       const bounds = getBoundFromPoints(points);
       map.fitBounds(bounds);
+
+      const polyline = new google.maps.Polyline({
+        path: points,
+        geodesic: true,
+        strokeColor: "#ff4747",
+        strokeOpacity: 0.5,
+        strokeWeight: 3,
+      });
+
+      setCurrentPolyline((prevPolyline) => {
+        prevPolyline?.setMap(null);
+        polyline.setMap(map);
+        return polyline;
+      });
     }
   }, [currentDay, map, plans.result]);
 

--- a/howaboutthere-fe/src/components/Domain/AISchedule/AISchedulePlan/SchedulePlanList/SchedulePlanListItem.tsx
+++ b/howaboutthere-fe/src/components/Domain/AISchedule/AISchedulePlan/SchedulePlanList/SchedulePlanListItem.tsx
@@ -1,0 +1,35 @@
+import { ActivityPlan, TransportPlan } from "@/types/plan-type";
+
+type SchedulePlanListItemProps = ActivityPlan & TransportPlan;
+
+export default function SchedulePlanListItem(props: SchedulePlanListItemProps) {
+  switch (props.type) {
+    case "activity":
+      return <ActivityPlanListItem {...props} />;
+    case "transport":
+      return <TransportPlanListItem {...props} />;
+    default:
+      return null;
+  }
+}
+
+type ActivityPlanListItemProps = ActivityPlan;
+function ActivityPlanListItem({ time, location, activity }: ActivityPlanListItemProps) {
+  return (
+    <article className="w-full p-4 flex flex-col gap-1.5 bg-white border border-sky-100 rounded-lg">
+      <small className="text-stone-500">{time}</small>
+      <h3 className="text-stone-900">{location}</h3>
+      <p className="text-stone-600">{activity}</p>
+    </article>
+  );
+}
+
+type TransportPlanListItemProps = TransportPlan;
+function TransportPlanListItem({ method, duration }: TransportPlanListItemProps) {
+  return (
+    <article className="p-2 flex flex-row items-center gap-2 bg-sky-100 border  border-sky-200 rounded-lg">
+      <h3 className="text-sky-900">{method}</h3>
+      <p className="text-sky-600">약 {duration}분</p>
+    </article>
+  );
+}

--- a/howaboutthere-fe/src/components/Domain/AISchedule/AISchedulePlan/SchedulePlanList/SchedulePlanListItem.tsx
+++ b/howaboutthere-fe/src/components/Domain/AISchedule/AISchedulePlan/SchedulePlanList/SchedulePlanListItem.tsx
@@ -1,13 +1,13 @@
 import { ActivityPlan, TransportPlan } from "@/types/plan-type";
 
-type SchedulePlanListItemProps = ActivityPlan & TransportPlan;
+type SchedulePlanListItemProps = ActivityPlan | TransportPlan;
 
 export default function SchedulePlanListItem(props: SchedulePlanListItemProps) {
   switch (props.type) {
     case "activity":
-      return <ActivityPlanListItem {...props} />;
+      return <ActivityPlanListItem {...(props as ActivityPlan)} />;
     case "transport":
-      return <TransportPlanListItem {...props} />;
+      return <TransportPlanListItem {...(props as TransportPlan)} />;
     default:
       return null;
   }

--- a/howaboutthere-fe/src/components/Domain/AISchedule/AISchedulePlan/SchedulePlanSummary.tsx
+++ b/howaboutthere-fe/src/components/Domain/AISchedule/AISchedulePlan/SchedulePlanSummary.tsx
@@ -1,0 +1,12 @@
+type SchedulePlanSummaryProps = {
+  summary: string;
+};
+
+export default function SchedulePlanSummary({ summary }: SchedulePlanSummaryProps) {
+  return (
+    <div className="p-4  flex flex-col gap-1 border rounded-lg border-sky-100">
+      <h3 className="text-sky-900">🪄 AI 일정 요약</h3>
+      <p className="leading-normal text-stone-600">{summary}</p>
+    </div>
+  );
+}

--- a/howaboutthere-fe/src/mocks/ai-schedule-plan-mock.json
+++ b/howaboutthere-fe/src/mocks/ai-schedule-plan-mock.json
@@ -1,0 +1,207 @@
+{
+  "result": [
+    {
+      "date": "2024-10-13",
+      "description": "오늘은 다낭에서의 첫날로, 실용적인 쇼핑과 자연 탐험, 그리고 현지 문화 체험의 완벽한 조화를 경험하실 수 있습니다. 롯데마트에서의 쇼핑으로 시작해 후옌콩 동굴의 신비로운 자연을 거쳐, 호이안 야시장의 활기찬 분위기로 마무리되는 흥미진진한 하루가 될 것입니다.",
+      "schedule": [
+        {
+          "type": "activity",
+          "time": "10:00",
+          "location": "롯데마트 다낭점",
+          "latlng": [16.034472, 108.2281336],
+          "activity": "필요한 물품 구매 및 쇼핑하기",
+          "duration": 30
+        },
+        {
+          "type": "transport",
+          "method": "taxi",
+          "duration": 30
+        },
+        {
+          "type": "activity",
+          "time": "14:00",
+          "location": "Huyen Khong Cave",
+          "latlng": [16.0047814, 108.2590678],
+          "activity": "다낭의 유명한 자연 명소 관광",
+          "duration": 45
+        },
+        {
+          "type": "transport",
+          "method": "taxi",
+          "duration": 45
+        },
+        {
+          "type": "activity",
+          "time": "19:00",
+          "location": "호이안 야시장",
+          "latlng": [15.8759693, 108.3234381],
+          "activity": "현지 문화 체험 및 야시장 탐방",
+          "duration": 120
+        }
+      ]
+    },
+    {
+      "date": "2024-10-14",
+      "description": "다낭의 아름다운 해변과 현대적인 명소를 탐험하는 날입니다. 미케비치의 황금빛 모래사장에서 여유로운 오전을 보내고, 독특한 건축미의 골든브릿지를 거쳐, 화려한 야경이 펼쳐지는 한강브릿지에서 하루를 마무리합니다. 자연과 현대 건축의 조화를 느낄 수 있는 특별한 하루가 될 것입니다.",
+      "schedule": [
+        {
+          "type": "activity",
+          "time": "09:00",
+          "location": "미케비치",
+          "latlng": [16.0521419, 108.2293575],
+          "activity": "해변에서 휴식 및 수영",
+          "duration": 180
+        },
+        {
+          "type": "transport",
+          "method": "bus",
+          "duration": 45
+        },
+        {
+          "type": "activity",
+          "time": "14:00",
+          "location": "골든브릿지",
+          "latlng": [15.994892, 107.9940028],
+          "activity": "바나힐 관광 및 골든브릿지 방문",
+          "duration": 180
+        },
+        {
+          "type": "transport",
+          "method": "taxi",
+          "duration": 30
+        },
+        {
+          "type": "activity",
+          "time": "20:00",
+          "location": "한강브릿지",
+          "latlng": [16.0665368, 108.2249211],
+          "activity": "야경 감상",
+          "duration": 60
+        }
+      ]
+    },
+    {
+      "date": "2024-10-15",
+      "description": "오늘은 베트남의 역사와 문화에 깊이 빠져드는 날입니다. 참 박물관에서 베트남 전쟁의 역사를 배우고, 마블마운틴의 영적인 분위기를 느낀 후, 전통 요리 클래스로 베트남 음식 문화를 직접 체험합니다. 과거와 현재가 공존하는 베트남의 다채로운 모습을 경험하는 의미 있는 하루가 될 것입니다.",
+      "schedule": [
+        {
+          "type": "activity",
+          "time": "09:30",
+          "location": "참 박물관",
+          "latlng": [16.0603007, 108.2206874],
+          "activity": "박물관 관람",
+          "duration": 120
+        },
+        {
+          "type": "transport",
+
+          "method": "taxi",
+          "duration": 20
+        },
+        {
+          "type": "activity",
+          "time": "13:00",
+          "location": "마블마운틴",
+          "latlng": [16.0034756, 108.262],
+          "activity": "사원 방문 및 동굴 탐험",
+          "duration": 180
+        },
+        {
+          "type": "transport",
+
+          "method": "taxi",
+          "duration": 25
+        },
+        {
+          "type": "activity",
+          "time": "18:00",
+          "location": "현지 요리 학교",
+          "latlng": [16.0276658, 108.2428288],
+          "activity": "베트남 요리 클래스",
+          "duration": 150
+        }
+      ]
+    },
+    {
+      "date": "2024-10-16",
+      "description": "다낭 주변의 유네스코 세계문화유산을 탐험하는 날입니다. 미손 유적지에서 고대 참파 왕국의 신비로운 흔적을 만나고, 호이안 고대도시에서는 베트남의 전통적인 건축과 문화를 체험합니다. 역사의 숨결이 살아있는 장소들을 방문하며 베트남의 풍부한 문화유산을 깊이 있게 이해하는 시간이 될 것입니다.",
+      "schedule": [
+        {
+          "type": "activity",
+          "time": "09:30",
+          "location": "미손 유적지",
+          "latlng": [15.7687821, 108.1167351],
+          "activity": "고대 유적지 탐방",
+          "duration": 180
+        },
+        {
+          "type": "transport",
+          "method": "bus",
+          "duration": 60
+        },
+
+        {
+          "type": "activity",
+          "time": "20:00",
+          "location": "포슈아 강변",
+          "latlng": [15.8769354, 108.3356754],
+          "activity": "강변 디너",
+          "duration": 90
+        }
+      ]
+    },
+    {
+      "date": "2024-10-17",
+      "description": "여행의 마지막 날은 다낭의 현대적인 면모와 전통적인 시장을 경험하는 시간입니다. 드래곤 브릿지에서 시작해 콘다오 시장의 활기찬 분위기를 만끽하고, 손 트라 해변에서 여유로운 시간을 보냅니다. 마지막으로 아시아파크에서 즐거운 놀이기구와 화려한 쇼를 즐기며 여행의 대미를 장식합니다. 다낭의 다양한 매력을 한 번에 느낄 수 있는 풍성한 하루가 될 것입니다.",
+      "schedule": [
+        {
+          "type": "activity",
+          "time": "08:00",
+          "location": "드래곤 브릿지",
+          "latlng": [16.0611377, 108.2246288],
+          "activity": "브릿지 관광",
+          "duration": 60
+        },
+        {
+          "type": "transport",
+          "method": "walk",
+          "duration": 15
+        },
+        {
+          "type": "activity",
+          "time": "09:30",
+          "location": "Con Market",
+          "latlng": [16.0705452, 108.1850006],
+          "activity": "현지 시장 체험",
+          "duration": 120
+        },
+        {
+          "type": "transport",
+          "method": "taxi",
+          "duration": 20
+        },
+        {
+          "type": "activity",
+          "time": "13:00",
+          "location": "선짜 남쪽해변",
+          "latlng": [16.1050883, 108.2615011],
+          "activity": "해변 휴식 및 수상 활동",
+          "duration": 180
+        },
+        {
+          "type": "transport",
+          "method": "taxi",
+          "duration": 25
+        },
+        {
+          "type": "activity",
+          "time": "18:00",
+          "location": "아시아파크",
+          "latlng": [16.0412139, 108.2230529],
+          "activity": "놀이공원 체험 및 야간 쇼 관람",
+          "duration": 240
+        }
+      ]
+    }
+  ]
+}

--- a/howaboutthere-fe/src/mocks/ai-schedule-plan-mock.json
+++ b/howaboutthere-fe/src/mocks/ai-schedule-plan-mock.json
@@ -5,36 +5,41 @@
       "description": "오늘은 다낭에서의 첫날로, 실용적인 쇼핑과 자연 탐험, 그리고 현지 문화 체험의 완벽한 조화를 경험하실 수 있습니다. 롯데마트에서의 쇼핑으로 시작해 후옌콩 동굴의 신비로운 자연을 거쳐, 호이안 야시장의 활기찬 분위기로 마무리되는 흥미진진한 하루가 될 것입니다.",
       "schedule": [
         {
+          "id": 1,
           "type": "activity",
           "time": "10:00",
           "location": "롯데마트 다낭점",
-          "latlng": [16.034472, 108.2281336],
+          "latlng": { "lat": 16.034472, "lng": 108.2281336 },
           "activity": "필요한 물품 구매 및 쇼핑하기",
           "duration": 30
         },
         {
+          "id": 2,
           "type": "transport",
           "method": "taxi",
           "duration": 30
         },
         {
+          "id": 3,
           "type": "activity",
           "time": "14:00",
           "location": "Huyen Khong Cave",
-          "latlng": [16.0047814, 108.2590678],
+          "latlng": { "lat": 16.0047814, "lng": 108.2590678 },
           "activity": "다낭의 유명한 자연 명소 관광",
           "duration": 45
         },
         {
+          "id": 4,
           "type": "transport",
           "method": "taxi",
           "duration": 45
         },
         {
+          "id": 5,
           "type": "activity",
           "time": "19:00",
           "location": "호이안 야시장",
-          "latlng": [15.8759693, 108.3234381],
+          "latlng": { "lat": 15.8759693, "lng": 108.3234381 },
           "activity": "현지 문화 체험 및 야시장 탐방",
           "duration": 120
         }
@@ -45,36 +50,41 @@
       "description": "다낭의 아름다운 해변과 현대적인 명소를 탐험하는 날입니다. 미케비치의 황금빛 모래사장에서 여유로운 오전을 보내고, 독특한 건축미의 골든브릿지를 거쳐, 화려한 야경이 펼쳐지는 한강브릿지에서 하루를 마무리합니다. 자연과 현대 건축의 조화를 느낄 수 있는 특별한 하루가 될 것입니다.",
       "schedule": [
         {
+          "id": 1,
           "type": "activity",
           "time": "09:00",
           "location": "미케비치",
-          "latlng": [16.0521419, 108.2293575],
+          "latlng": { "lat": 16.0521419, "lng": 108.2293575 },
           "activity": "해변에서 휴식 및 수영",
           "duration": 180
         },
         {
+          "id": 2,
           "type": "transport",
           "method": "bus",
           "duration": 45
         },
         {
+          "id": 3,
           "type": "activity",
           "time": "14:00",
           "location": "골든브릿지",
-          "latlng": [15.994892, 107.9940028],
+          "latlng": { "lat": 15.994892, "lng": 107.9940028 },
           "activity": "바나힐 관광 및 골든브릿지 방문",
           "duration": 180
         },
         {
+          "id": 4,
           "type": "transport",
           "method": "taxi",
           "duration": 30
         },
         {
+          "id": 5,
           "type": "activity",
           "time": "20:00",
           "location": "한강브릿지",
-          "latlng": [16.0665368, 108.2249211],
+          "latlng": { "lat": 16.0665368, "lng": 108.2249211 },
           "activity": "야경 감상",
           "duration": 60
         }
@@ -85,38 +95,41 @@
       "description": "오늘은 베트남의 역사와 문화에 깊이 빠져드는 날입니다. 참 박물관에서 베트남 전쟁의 역사를 배우고, 마블마운틴의 영적인 분위기를 느낀 후, 전통 요리 클래스로 베트남 음식 문화를 직접 체험합니다. 과거와 현재가 공존하는 베트남의 다채로운 모습을 경험하는 의미 있는 하루가 될 것입니다.",
       "schedule": [
         {
+          "id": 1,
           "type": "activity",
           "time": "09:30",
           "location": "참 박물관",
-          "latlng": [16.0603007, 108.2206874],
+          "latlng": { "lat": 16.0603007, "lng": 108.2206874 },
           "activity": "박물관 관람",
           "duration": 120
         },
         {
+          "id": 2,
           "type": "transport",
-
           "method": "taxi",
           "duration": 20
         },
         {
+          "id": 3,
           "type": "activity",
           "time": "13:00",
           "location": "마블마운틴",
-          "latlng": [16.0034756, 108.262],
+          "latlng": { "lat": 16.0034756, "lng": 108.262 },
           "activity": "사원 방문 및 동굴 탐험",
           "duration": 180
         },
         {
+          "id": 4,
           "type": "transport",
-
           "method": "taxi",
           "duration": 25
         },
         {
+          "id": 5,
           "type": "activity",
           "time": "18:00",
           "location": "현지 요리 학교",
-          "latlng": [16.0276658, 108.2428288],
+          "latlng": { "lat": 16.0276658, "lng": 108.2428288 },
           "activity": "베트남 요리 클래스",
           "duration": 150
         }
@@ -127,24 +140,26 @@
       "description": "다낭 주변의 유네스코 세계문화유산을 탐험하는 날입니다. 미손 유적지에서 고대 참파 왕국의 신비로운 흔적을 만나고, 호이안 고대도시에서는 베트남의 전통적인 건축과 문화를 체험합니다. 역사의 숨결이 살아있는 장소들을 방문하며 베트남의 풍부한 문화유산을 깊이 있게 이해하는 시간이 될 것입니다.",
       "schedule": [
         {
+          "id": 1,
           "type": "activity",
           "time": "09:30",
           "location": "미손 유적지",
-          "latlng": [15.7687821, 108.1167351],
+          "latlng": { "lat": 15.7687821, "lng": 108.1167351 },
           "activity": "고대 유적지 탐방",
           "duration": 180
         },
         {
+          "id": 2,
           "type": "transport",
           "method": "bus",
           "duration": 60
         },
-
         {
+          "id": 3,
           "type": "activity",
           "time": "20:00",
           "location": "포슈아 강변",
-          "latlng": [15.8769354, 108.3356754],
+          "latlng": { "lat": 15.8769354, "lng": 108.3356754 },
           "activity": "강변 디너",
           "duration": 90
         }
@@ -155,49 +170,56 @@
       "description": "여행의 마지막 날은 다낭의 현대적인 면모와 전통적인 시장을 경험하는 시간입니다. 드래곤 브릿지에서 시작해 콘다오 시장의 활기찬 분위기를 만끽하고, 손 트라 해변에서 여유로운 시간을 보냅니다. 마지막으로 아시아파크에서 즐거운 놀이기구와 화려한 쇼를 즐기며 여행의 대미를 장식합니다. 다낭의 다양한 매력을 한 번에 느낄 수 있는 풍성한 하루가 될 것입니다.",
       "schedule": [
         {
+          "id": 1,
           "type": "activity",
           "time": "08:00",
           "location": "드래곤 브릿지",
-          "latlng": [16.0611377, 108.2246288],
+          "latlng": { "lat": 16.0611377, "lng": 108.2246288 },
           "activity": "브릿지 관광",
           "duration": 60
         },
         {
+          "id": 2,
           "type": "transport",
           "method": "walk",
           "duration": 15
         },
         {
+          "id": 3,
           "type": "activity",
           "time": "09:30",
           "location": "Con Market",
-          "latlng": [16.0705452, 108.1850006],
+          "latlng": { "lat": 16.0705452, "lng": 108.1850006 },
           "activity": "현지 시장 체험",
           "duration": 120
         },
         {
+          "id": 4,
           "type": "transport",
           "method": "taxi",
           "duration": 20
         },
         {
+          "id": 5,
           "type": "activity",
           "time": "13:00",
           "location": "선짜 남쪽해변",
-          "latlng": [16.1050883, 108.2615011],
+          "latlng": { "lat": 16.1050883, "lng": 108.2615011 },
           "activity": "해변 휴식 및 수상 활동",
           "duration": 180
         },
         {
+          "id": 6,
           "type": "transport",
           "method": "taxi",
           "duration": 25
         },
         {
+          "id": 7,
           "type": "activity",
           "time": "18:00",
           "location": "아시아파크",
-          "latlng": [16.0412139, 108.2230529],
+          "latlng": { "lat": 16.0412139, "lng": 108.2230529 },
           "activity": "놀이공원 체험 및 야간 쇼 관람",
           "duration": 240
         }

--- a/howaboutthere-fe/src/pages/ui-components/UIComponents.tsx
+++ b/howaboutthere-fe/src/pages/ui-components/UIComponents.tsx
@@ -1,6 +1,7 @@
 import AIScheduleFormCard from "@/components/Domain/AISchedule/AIScheduleForm/AIScheduleFormCard";
 import AIScheduleLocationCard from "@/components/Domain/AISchedule/AIScheduleLocation/AIScheduleLocationCard";
 import ScheduleLocationItem from "@/components/Domain/AISchedule/AIScheduleLocation/ScheduleLocationList/ScheduleLocationItem";
+import AISchedulePlanCard from "@/components/Domain/AISchedule/AISchedulePlan/AISchedulePlanCard";
 import AIScheduleThemeCard from "@/components/Domain/AISchedule/AIScheduleTheme/AIScheduleThemeCard";
 import ScheduleThemeItem from "@/components/Domain/AISchedule/AIScheduleTheme/ScheduleThemeList/ScheduleThemeItem";
 
@@ -51,6 +52,10 @@ export default function UIComponents() {
             lng: 0,
           }}
         />
+      </div>
+      <div className="p-6">
+        <h2 className="mb-4 text-rose-500">AISchedulePlanCard</h2>
+        <AISchedulePlanCard />
       </div>
     </div>
   );

--- a/howaboutthere-fe/src/types/plan-type.ts
+++ b/howaboutthere-fe/src/types/plan-type.ts
@@ -1,0 +1,19 @@
+export type PlanType = "activity" | "transport";
+export type TransportType = "taxi" | "bus" | "subway" | "walk";
+
+export type Plan = {
+  type: PlanType;
+  duration: number;
+};
+
+export type ActivityPlan = Plan & {
+  time: string;
+  location: string;
+  activity: string;
+};
+
+export type TransportPlan = Plan & {
+  type: PlanType;
+  method: TransportType;
+  duration: number;
+};

--- a/howaboutthere-fe/src/types/plan-type.ts
+++ b/howaboutthere-fe/src/types/plan-type.ts
@@ -1,7 +1,10 @@
+import { LatLng } from "./location-type";
+
 export type PlanType = "activity" | "transport";
 export type TransportType = "taxi" | "bus" | "subway" | "walk";
 
 export type Plan = {
+  id: number;
   type: PlanType;
   duration: number;
 };
@@ -9,6 +12,7 @@ export type Plan = {
 export type ActivityPlan = Plan & {
   time: string;
   location: string;
+  latlng: LatLng;
   activity: string;
 };
 

--- a/howaboutthere-fe/tailwind.config.js
+++ b/howaboutthere-fe/tailwind.config.js
@@ -63,7 +63,7 @@ export default {
               fontFamily: "Paperlogy",
               fontWeight: "800",
             },
-            "p, pre, table, ul, ol, blockquote, span": {
+            "p, pre, table, ul, ol, blockquote, span, small": {
               fontFamily: "Pretendard Variable",
             },
           },


### PR DESCRIPTION
# 작업 내용
- [x] map 내 polygon 적용
- [x] SchedulePlanListItem 구현
- [x] AISchedulePlanCard 구현

## map 내 polygon 적용
![image](https://github.com/user-attachments/assets/0690d4f9-5867-47c6-a7e8-5a058d5a718f)
```ts
const polyline = new google.maps.Polyline({
  path: points,
  geodesic: true,
  strokeColor: "#ff4747",
  strokeOpacity: 0.5,
  strokeWeight: 3,
});

setCurrentPolyline((prevPolyline) => {
  prevPolyline?.setMap(null);
  polyline.setMap(map);
  return polyline;
});
```
- polyline 생성 후 map 적용
- 새 polyline 생성 시 이전 polyline 초기화를 위해 state로 관리

### 추후 개선
- [ ] polyline을 배열로 관리하여 생성한 polygon을 재사용할 수 있도록 할 예정

## AISchedulePlanCard 구현
![지도 polygon](https://github.com/user-attachments/assets/db9a128a-ca96-4c1d-a95c-0ec0997904e9)

```ts
const [currentDay, setCurrentDay] = useState(0);
```
- currentDay를 state로 관리하여 페이지 전체의 ui가 유기적으로 구성될 수 있도록 함

<img src=https://github.com/user-attachments/assets/d0d3d573-eb1e-4d71-9d1d-a741e4c68b55 width=320/>
- 해당 일정의 type (activity or transport)에 따라서 다른 UI로 렌더링되도록 함